### PR TITLE
Add a mechanism for including a layer of ghost cells for the VisIt reader

### DIFF
--- a/include/sdf.h
+++ b/include/sdf.h
@@ -352,6 +352,13 @@ struct sdf_file {
     FILE *filehandle;
 #endif
     comm_t comm;
+
+    /* Flag to tell the function sdf_get_domain_bounds that one layer
+     * of ghost cells is required for the VisIt reader, but we cannot
+     * use MPI communications to exchange ghost cell data between
+     * processes.
+     */
+    int par_visit;
 };
 
 struct run_info {


### PR DESCRIPTION
This is a fix for issue 196 on our bug tracker. Another pull request will accompany it on the VisIt repo.

Could you check over it first before merging it into devel, to make sure it doesn't break anything?


---------------------------------------------------------------------------------
This allows a layer of ghost cells to be read directly from the SDF
file, without communicating data between processors. This is necessary
when the function sdf_helper_read_data is called from a VisIt function
that uses dynamic load balancing. (See p141-2 of the manual
GettingDataIntoVisIt.)